### PR TITLE
Fix health endpoint to check actual dependencies

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -87,6 +87,11 @@ func (db *DB) Pool() *pgxpool.Pool {
 	return db.pool
 }
 
+// Ping checks database connectivity
+func (db *DB) Ping(ctx context.Context) error {
+	return db.pool.Ping(ctx)
+}
+
 // BeginTx starts a new transaction
 func (db *DB) BeginTx(ctx context.Context) (pgx.Tx, error) {
 	return db.pool.Begin(ctx)

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -1,17 +1,28 @@
 package handlers
 
 import (
+	"context"
+	"net/http"
 	"time"
+
+	"stronghold/internal/config"
+	"stronghold/internal/db"
 
 	"github.com/gofiber/fiber/v3"
 )
 
 // HealthHandler handles health check endpoints
-type HealthHandler struct{}
+type HealthHandler struct {
+	db     *db.DB
+	config *config.Config
+}
 
 // NewHealthHandler creates a new health handler
-func NewHealthHandler() *HealthHandler {
-	return &HealthHandler{}
+func NewHealthHandler(database *db.DB, cfg *config.Config) *HealthHandler {
+	return &HealthHandler{
+		db:     database,
+		config: cfg,
+	}
 }
 
 // HealthResponse represents the health check response
@@ -37,14 +48,31 @@ func (h *HealthHandler) RegisterRoutes(app *fiber.App) {
 // @Success 200 {object} HealthResponse
 // @Router /health [get]
 func (h *HealthHandler) Health(c fiber.Ctx) error {
+	services := make(map[string]string)
+	overallStatus := "healthy"
+
+	// Check database
+	dbStatus := h.checkDatabase()
+	services["database"] = dbStatus
+	if dbStatus != "up" {
+		overallStatus = "degraded"
+	}
+
+	// Check x402 facilitator
+	if x402Status := h.checkX402Facilitator(); x402Status != "up" {
+		overallStatus = "degraded"
+		services["x402"] = x402Status
+	} else {
+		services["x402"] = "up"
+	}
+
+	// API is always up if we're responding
+	services["api"] = "up"
+
 	return c.JSON(HealthResponse{
-		Status:  "healthy",
-		Version: "1.0.0",
-		Services: map[string]string{
-			"api":     "up",
-			"citadel": "up",
-			"x402":    "up",
-		},
+		Status:    overallStatus,
+		Version:   "1.0.0",
+		Services:  services,
 		Timestamp: time.Now().Unix(),
 	})
 }
@@ -68,10 +96,66 @@ func (h *HealthHandler) Liveness(c fiber.Ctx) error {
 // @Tags health
 // @Produce json
 // @Success 200 {object} map[string]string
+// @Success 503 {object} map[string]string
 // @Router /health/ready [get]
 func (h *HealthHandler) Readiness(c fiber.Ctx) error {
-	// TODO: Check actual dependencies
+	// Check database connectivity
+	if dbStatus := h.checkDatabase(); dbStatus != "up" {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"status":   "not_ready",
+			"reason":   "database_unavailable",
+			"database": dbStatus,
+		})
+	}
+
+	// Check x402 facilitator reachability
+	if x402Status := h.checkX402Facilitator(); x402Status != "up" {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"status": "not_ready",
+			"reason": "x402_unavailable",
+			"x402":   x402Status,
+		})
+	}
+
 	return c.JSON(fiber.Map{
 		"status": "ready",
 	})
+}
+
+// checkDatabase verifies database connectivity
+func (h *HealthHandler) checkDatabase() string {
+	if h.db == nil {
+		return "not_configured"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	if err := h.db.Ping(ctx); err != nil {
+		return "down"
+	}
+	return "up"
+}
+
+// checkX402Facilitator verifies x402 facilitator is reachable
+func (h *HealthHandler) checkX402Facilitator() string {
+	if h.config == nil || h.config.X402.FacilitatorURL == "" {
+		return "not_configured"
+	}
+
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+
+	resp, err := client.Head(h.config.X402.FacilitatorURL)
+	if err != nil {
+		return "unreachable"
+	}
+	defer resp.Body.Close()
+
+	// Accept 2xx, 3xx, or 405 (Method Not Allowed - means server is up but doesn't support HEAD)
+	if resp.StatusCode < 500 {
+		return "up"
+	}
+	return "error"
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -124,7 +124,7 @@ func (s *Server) setupRoutes() {
 	x402 := middleware.NewX402Middleware(&s.config.X402, &s.config.Pricing)
 
 	// Health handler (no payment required)
-	healthHandler := handlers.NewHealthHandler()
+	healthHandler := handlers.NewHealthHandler(s.database, s.config)
 	healthHandler.RegisterRoutes(s.app)
 
 	// Pricing handler (no payment required)


### PR DESCRIPTION
## Summary
- `/health/ready` now checks database connectivity and x402 facilitator reachability
- Returns 503 with diagnostic info when dependencies are unavailable
- `/health` reports real status of all services (healthy/degraded)
- Adds 3-second timeouts for all health checks

## Test plan
- [ ] Start API without database running, verify `/health/ready` returns 503 with `database: down`
- [ ] Start API with database, verify `/health/ready` returns 200 with `status: ready`
- [ ] Configure invalid x402 facilitator URL, verify `/health/ready` returns 503
- [ ] Verify `/health` shows degraded status when any dependency is down