### PR TITLE
Add request ID tracking for distributed tracing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ This document tracks the remaining work needed to launch Stronghold in productio
 
 - [ ] **Add structured logging** - Currently using basic `log` package
   - Switch to `log/slog` or `zap` with JSON output
-  - Add request ID to all log entries
+  - ~~Add request ID to all log entries~~ (done - request IDs now included in logs)
   - Resolve TODO at `internal/handlers/auth.go:196`
 
 - [ ] **Fix health endpoint** - `internal/handlers/health.go:73` returns hardcoded "up"
@@ -50,7 +50,7 @@ This document tracks the remaining work needed to launch Stronghold in productio
   - [ ] Error boundaries for React components
   - [ ] Better loading states
 
-- [ ] **Add request ID tracking** - Missing distributed tracing
+- [x] **Add request ID tracking** - Missing distributed tracing
   - Generate UUID per request
   - Include in all log entries and error responses
 

--- a/internal/handlers/scan.go
+++ b/internal/handlers/scan.go
@@ -5,7 +5,6 @@ import (
 	"stronghold/internal/stronghold"
 
 	"github.com/gofiber/fiber/v3"
-	"github.com/google/uuid"
 )
 
 // ScanHandler handles scan-related endpoints
@@ -81,23 +80,28 @@ func (h *ScanHandler) RegisterRoutes(app *fiber.App) {
 // @Failure 402 {object} map[string]interface{}
 // @Router /v1/scan/content [post]
 func (h *ScanHandler) ScanContent(c fiber.Ctx) error {
+	requestID := middleware.GetRequestID(c)
+
 	var req ScanContentRequest
 	if err := c.Bind().Body(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid request body",
+			"error":      "Invalid request body",
+			"request_id": requestID,
 		})
 	}
 
 	if req.Text == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Text is required",
+			"error":      "Text is required",
+			"request_id": requestID,
 		})
 	}
 
 	result, err := h.scanner.ScanContent(c.Context(), req.Text, req.SourceURL, req.SourceType, req.ContentType)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Scan failed: " + err.Error(),
+			"error":      "Scan failed: " + err.Error(),
+			"request_id": requestID,
 		})
 	}
 
@@ -110,7 +114,7 @@ func (h *ScanHandler) ScanContent(c fiber.Ctx) error {
 	result.Metadata["content_type"] = req.ContentType
 	result.Metadata["file_path"] = req.FilePath
 
-	result.RequestID = uuid.New().String()
+	result.RequestID = requestID
 	h.x402.PaymentResponse(c, result.RequestID)
 
 	return c.JSON(result)
@@ -128,27 +132,32 @@ func (h *ScanHandler) ScanContent(c fiber.Ctx) error {
 // @Failure 402 {object} map[string]interface{}
 // @Router /v1/scan/output [post]
 func (h *ScanHandler) ScanOutput(c fiber.Ctx) error {
+	requestID := middleware.GetRequestID(c)
+
 	var req ScanOutputRequest
 	if err := c.Bind().Body(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid request body",
+			"error":      "Invalid request body",
+			"request_id": requestID,
 		})
 	}
 
 	if req.Text == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Text is required",
+			"error":      "Text is required",
+			"request_id": requestID,
 		})
 	}
 
 	result, err := h.scanner.ScanOutput(c.Context(), req.Text)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Scan failed: " + err.Error(),
+			"error":      "Scan failed: " + err.Error(),
+			"request_id": requestID,
 		})
 	}
 
-	result.RequestID = uuid.New().String()
+	result.RequestID = requestID
 	h.x402.PaymentResponse(c, result.RequestID)
 
 	return c.JSON(result)
@@ -166,16 +175,20 @@ func (h *ScanHandler) ScanOutput(c fiber.Ctx) error {
 // @Failure 402 {object} map[string]interface{}
 // @Router /v1/scan [post]
 func (h *ScanHandler) ScanUnified(c fiber.Ctx) error {
+	requestID := middleware.GetRequestID(c)
+
 	var req ScanUnifiedRequest
 	if err := c.Bind().Body(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid request body",
+			"error":      "Invalid request body",
+			"request_id": requestID,
 		})
 	}
 
 	if req.Text == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Text is required",
+			"error":      "Text is required",
+			"request_id": requestID,
 		})
 	}
 
@@ -186,18 +199,20 @@ func (h *ScanHandler) ScanUnified(c fiber.Ctx) error {
 
 	if mode != "input" && mode != "output" && mode != "both" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid mode. Must be 'input', 'output', or 'both'",
+			"error":      "Invalid mode. Must be 'input', 'output', or 'both'",
+			"request_id": requestID,
 		})
 	}
 
 	result, err := h.scanner.ScanUnified(c.Context(), req.Text, mode)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Scan failed: " + err.Error(),
+			"error":      "Scan failed: " + err.Error(),
+			"request_id": requestID,
 		})
 	}
 
-	result.RequestID = uuid.New().String()
+	result.RequestID = requestID
 	h.x402.PaymentResponse(c, result.RequestID)
 
 	return c.JSON(result)
@@ -215,33 +230,39 @@ func (h *ScanHandler) ScanUnified(c fiber.Ctx) error {
 // @Failure 402 {object} map[string]interface{}
 // @Router /v1/scan/multiturn [post]
 func (h *ScanHandler) ScanMultiturn(c fiber.Ctx) error {
+	requestID := middleware.GetRequestID(c)
+
 	var req ScanMultiturnRequest
 	if err := c.Bind().Body(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid request body",
+			"error":      "Invalid request body",
+			"request_id": requestID,
 		})
 	}
 
 	if req.SessionID == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "Session ID is required",
+			"error":      "Session ID is required",
+			"request_id": requestID,
 		})
 	}
 
 	if len(req.Turns) == 0 {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-			"error": "At least one turn is required",
+			"error":      "At least one turn is required",
+			"request_id": requestID,
 		})
 	}
 
 	result, err := h.scanner.ScanMultiturn(c.Context(), req.SessionID, req.Turns)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Scan failed: " + err.Error(),
+			"error":      "Scan failed: " + err.Error(),
+			"request_id": requestID,
 		})
 	}
 
-	result.RequestID = uuid.New().String()
+	result.RequestID = requestID
 	h.x402.PaymentResponse(c, result.RequestID)
 
 	return c.JSON(result)

--- a/internal/middleware/requestid.go
+++ b/internal/middleware/requestid.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+)
+
+const (
+	// RequestIDHeader is the header name for the request ID
+	RequestIDHeader = "X-Request-ID"
+	// RequestIDKey is the key used to store the request ID in Fiber's Locals
+	RequestIDKey = "request_id"
+)
+
+// RequestID returns middleware that generates a unique request ID for each request.
+// The request ID is stored in c.Locals("request_id") and added to the response header.
+// If the client provides an X-Request-ID header, that value is used instead.
+func RequestID() fiber.Handler {
+	return func(c fiber.Ctx) error {
+		// Check if client provided a request ID
+		requestID := c.Get(RequestIDHeader)
+		if requestID == "" {
+			// Generate a new UUID
+			requestID = uuid.New().String()
+		}
+
+		// Store in Locals for use by handlers and error handler
+		c.Locals(RequestIDKey, requestID)
+
+		// Add to response header
+		c.Set(RequestIDHeader, requestID)
+
+		return c.Next()
+	}
+}
+
+// GetRequestID retrieves the request ID from the Fiber context.
+// Returns an empty string if no request ID is set.
+func GetRequestID(c fiber.Ctx) string {
+	if id, ok := c.Locals(RequestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- Implements request ID tracking as specified in ROADMAP.md
- Generates unique UUIDs for each incoming request via new middleware
- Includes request ID in all log entries, error responses, and response headers

## Changes
- **New**: `internal/middleware/requestid.go` - Request ID middleware with `GetRequestID()` helper
- **Updated**: `internal/server/server.go` - Register middleware, update logger format, CORS, and error handlers
- **Updated**: `internal/handlers/scan.go` - Use context request ID instead of generating per-response
- **Updated**: `ROADMAP.md` - Mark task as complete

## Features
- `X-Request-ID` response header on all responses
- Client-provided `X-Request-ID` header is respected (for distributed tracing)
- Request ID included in Fiber logs: `[${locals:request_id}]`
- All error responses include `request_id` field

## Test plan
- [ ] Verify `X-Request-ID` header appears in all responses
- [ ] Verify client-provided request IDs are passed through
- [ ] Verify request IDs appear in server logs
- [ ] Verify error responses include `request_id` field