### PR TITLE
Add rate limiting for API protection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	X402       X402Config
 	Stronghold StrongholdConfig
 	Pricing    PricingConfig
+	RateLimit  RateLimitConfig
 }
 
 // ServerConfig holds HTTP server configuration
@@ -82,6 +83,16 @@ type PricingConfig struct {
 	ScanMultiturn float64
 }
 
+// RateLimitConfig holds rate limiting configuration
+type RateLimitConfig struct {
+	Enabled       bool
+	WindowSeconds int
+	MaxRequests   int
+	LoginMax      int
+	AccountMax    int
+	RefreshMax    int
+}
+
 // Load loads configuration from environment variables
 func Load() *Config {
 	return &Config{
@@ -132,6 +143,14 @@ func Load() *Config {
 			ScanUnified:   getFloat("PRICE_SCAN_UNIFIED", 0.002),
 			ScanMultiturn: getFloat("PRICE_SCAN_MULTITURN", 0.005),
 		},
+		RateLimit: RateLimitConfig{
+			Enabled:       getBool("RATE_LIMIT_ENABLED", true),
+			WindowSeconds: getInt("RATE_LIMIT_WINDOW_SECONDS", 60),
+			MaxRequests:   getInt("RATE_LIMIT_MAX_REQUESTS", 100),
+			LoginMax:      getInt("RATE_LIMIT_LOGIN_MAX", 5),
+			AccountMax:    getInt("RATE_LIMIT_ACCOUNT_MAX", 3),
+			RefreshMax:    getInt("RATE_LIMIT_REFRESH_MAX", 10),
+		},
 	}
 }
 
@@ -155,6 +174,15 @@ func getFloat(key string, defaultValue float64) float64 {
 	if value := os.Getenv(key); value != "" {
 		if f, err := strconv.ParseFloat(value, 64); err == nil {
 			return f
+		}
+	}
+	return defaultValue
+}
+
+func getInt(key string, defaultValue int) int {
+	if value := os.Getenv(key); value != "" {
+		if i, err := strconv.Atoi(value); err == nil {
+			return i
 		}
 	}
 	return defaultValue

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -138,7 +138,17 @@ func (h *AuthHandler) parseSameSite() string {
 
 // RegisterRoutes registers auth routes
 func (h *AuthHandler) RegisterRoutes(app *fiber.App) {
+	h.RegisterRoutesWithMiddleware(app)
+}
+
+// RegisterRoutesWithMiddleware registers auth routes with optional middleware
+func (h *AuthHandler) RegisterRoutesWithMiddleware(app *fiber.App, middlewares ...fiber.Handler) {
 	group := app.Group("/v1/auth")
+
+	// Apply any provided middleware to the group
+	for _, mw := range middlewares {
+		group.Use(mw)
+	}
 
 	group.Post("/account", h.CreateAccount)
 	group.Post("/login", h.Login)

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,0 +1,104 @@
+package middleware
+
+import (
+	"strings"
+	"time"
+
+	"stronghold/internal/config"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/limiter"
+)
+
+// RateLimitMiddleware provides rate limiting for the API
+type RateLimitMiddleware struct {
+	config *config.RateLimitConfig
+}
+
+// NewRateLimitMiddleware creates a new rate limit middleware instance
+func NewRateLimitMiddleware(cfg *config.RateLimitConfig) *RateLimitMiddleware {
+	return &RateLimitMiddleware{
+		config: cfg,
+	}
+}
+
+// Middleware returns the general rate limiter for all endpoints
+func (m *RateLimitMiddleware) Middleware() fiber.Handler {
+	if !m.config.Enabled {
+		return func(c fiber.Ctx) error {
+			return c.Next()
+		}
+	}
+
+	return limiter.New(limiter.Config{
+		Max:        m.config.MaxRequests,
+		Expiration: time.Duration(m.config.WindowSeconds) * time.Second,
+		KeyGenerator: func(c fiber.Ctx) string {
+			return c.IP()
+		},
+		LimitReached: rateLimitResponse,
+		SkipSuccessfulRequests: false,
+		SkipFailedRequests:     false,
+		Next: func(c fiber.Ctx) bool {
+			// Skip rate limiting for health endpoints
+			return isHealthEndpoint(c.Path())
+		},
+	})
+}
+
+// AuthLimiter returns a stricter rate limiter for auth endpoints
+func (m *RateLimitMiddleware) AuthLimiter() fiber.Handler {
+	if !m.config.Enabled {
+		return func(c fiber.Ctx) error {
+			return c.Next()
+		}
+	}
+
+	return limiter.New(limiter.Config{
+		MaxFunc:    m.getAuthLimit,
+		Expiration: time.Duration(m.config.WindowSeconds) * time.Second,
+		KeyGenerator: func(c fiber.Ctx) string {
+			// Key by IP + endpoint for per-endpoint limits
+			return c.IP() + ":" + c.Path()
+		},
+		LimitReached:           rateLimitResponse,
+		SkipSuccessfulRequests: false,
+		SkipFailedRequests:     false,
+	})
+}
+
+// getAuthLimit returns the appropriate limit based on the endpoint
+func (m *RateLimitMiddleware) getAuthLimit(c fiber.Ctx) int {
+	path := c.Path()
+
+	switch {
+	case strings.HasSuffix(path, "/login"):
+		return m.config.LoginMax
+	case strings.HasSuffix(path, "/account"):
+		return m.config.AccountMax
+	case strings.HasSuffix(path, "/refresh"):
+		return m.config.RefreshMax
+	default:
+		return m.config.MaxRequests
+	}
+}
+
+// rateLimitResponse returns a 429 Too Many Requests response
+func rateLimitResponse(c fiber.Ctx) error {
+	retryAfter := c.GetRespHeader("Retry-After")
+	if retryAfter == "" {
+		retryAfter = "60"
+	}
+
+	c.Set("Retry-After", retryAfter)
+	return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+		"error":       "Too many requests",
+		"message":     "Rate limit exceeded. Please try again later.",
+		"retry_after": retryAfter,
+	})
+}
+
+// isHealthEndpoint checks if the path is a health endpoint
+func isHealthEndpoint(path string) bool {
+	return strings.HasPrefix(path, "/health")
+}


### PR DESCRIPTION
## Summary
- Implements IP-based rate limiting using Fiber v3's built-in limiter middleware
- Adds tiered rate limits: general endpoints (100 req/60s) and stricter limits for auth endpoints (login: 5, account creation: 3, token refresh: 10)
- Configurable via environment variables (`RATE_LIMIT_ENABLED`, `RATE_LIMIT_WINDOW_SECONDS`, etc.)
- Returns 429 Too Many Requests with JSON body and `Retry-After` header when rate limited
- Health endpoints are excluded from rate limiting

## Test plan
- [ ] Start API with `go run ./cmd/api`
- [ ] Verify login rate limiting by sending 6+ requests to `/v1/auth/login` within 60s
- [ ] Verify general rate limiting by sending 101+ requests to any endpoint within 60s
- [ ] Verify health endpoints (`/health`, `/health/live`, `/health/ready`) are not rate limited
- [ ] Verify 429 response includes proper JSON body and `Retry-After` header