### PR TITLE
Fix mobile navigation menu background transparency

### DIFF
--- a/web/components/sections/Navigation.tsx
+++ b/web/components/sections/Navigation.tsx
@@ -31,8 +31,8 @@ export default function Navigation() {
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-        isScrolled
-          ? 'bg-stronghold-darker/80 backdrop-blur-xl border-b border-stronghold-stone-light/30'
+        isScrolled || isMobileMenuOpen
+          ? 'bg-stronghold-darker/95 backdrop-blur-xl border-b border-stronghold-stone-light/30'
           : 'bg-transparent'
       }`}
     >


### PR DESCRIPTION
Add background when mobile menu is open, not just when scrolled,
to prevent menu items from appearing over page content.

https://claude.ai/code/session_014CbMmjPCb8A7fu9yRTo5oG