### PR TITLE
Add wallet export command for private key backup

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -201,6 +201,28 @@ You can deposit via:
 
 	accountCmd.AddCommand(accountBalanceCmd, accountDepositCmd)
 
+	// Wallet command
+	walletCmd := &cobra.Command{
+		Use:   "wallet",
+		Short: "Manage your Stronghold wallet",
+	}
+
+	walletExportCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export wallet private key to a file",
+		Long: `Export your wallet private key to a file for backup.
+
+By default, exports to ~/.stronghold/wallet-backup
+Use --output to specify a different location.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output, _ := cmd.Flags().GetString("output")
+			return cli.ExportWallet(output)
+		},
+	}
+	walletExportCmd.Flags().StringP("output", "o", "", "Output file path (default: ~/.stronghold/wallet-backup)")
+
+	walletCmd.AddCommand(walletExportCmd)
+
 	// Doctor command
 	doctorCmd := &cobra.Command{
 		Use:   "doctor",
@@ -232,6 +254,7 @@ Run this before 'stronghold install' to catch issues early.`,
 		logsCmd,
 		configCmd,
 		accountCmd,
+		walletCmd,
 		doctorCmd,
 	)
 

--- a/internal/wallet/wallet.go
+++ b/internal/wallet/wallet.go
@@ -210,6 +210,16 @@ func (w *Wallet) Exists() bool {
 	return err == nil
 }
 
+// Export returns the private key as a hex string
+// WARNING: Handle with extreme care - this exposes sensitive key material
+func (w *Wallet) Export() (string, error) {
+	item, err := w.keyring.Get(w.keyID())
+	if err != nil {
+		return "", fmt.Errorf("wallet not found: %w", err)
+	}
+	return string(item.Data), nil
+}
+
 // GetBalance returns the USDC balance for this wallet
 func (w *Wallet) GetBalance(ctx context.Context) (*big.Int, error) {
 	if w.Address == (common.Address{}) {


### PR DESCRIPTION
## Summary
- Adds `stronghold wallet export` CLI command to export wallet private key to a file
- Defaults to `~/.stronghold/wallet-backup` with optional `-o/--output` flag for custom path
- Includes security warning and confirmation prompt before export
- Uses secure file permissions (0600 for file, 0700 for directory)

## Test plan
- [ ] Run `stronghold wallet export` and verify security warning appears
- [ ] Confirm the confirmation prompt works (y/n)
- [ ] Verify file is created at `~/.stronghold/wallet-backup` with correct permissions
- [ ] Run again to verify "Backup already exists" message
- [ ] Test `-o` flag with custom output path
- [ ] Test without wallet configured to verify error message