### PR TITLE
Refactor landing page copy and layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,18 @@ The platform provides 4-layer security scanning: heuristics, ML classification (
 - Only production code, tests, and essential documentation belong in the repo
 - If you need to write intermediate results, use `/tmp/` not the project root
 
+## Package Manager — ALWAYS BUN, NEVER ANYTHING ELSE
+
+**CRITICAL: The ONLY package manager for this project is `bun`. No exceptions.**
+
+- **NEVER** use `npm`, `npx`, `yarn`, or `pnpm` — not even once, not even for a quick command
+- Use `bun run <script>` to run scripts (NOT `npm run`)
+- Use `bun install` to install packages (NOT `npm install`)
+- Use `bunx` to run package binaries (NOT `npx`)
+- Use `bun add <pkg>` to add dependencies (NOT `npm install <pkg>`)
+
+If you catch yourself about to type `npm`, `npx`, `yarn`, or `pnpm` — STOP and use `bun` instead.
+
 ## Build Commands
 
 ```bash
@@ -44,7 +56,7 @@ go test ./...
 # Run a specific test
 go test ./internal/handlers -run TestScanContent
 
-# Frontend (in web/ directory) - USE BUN, NOT NPM
+# Frontend (in web/ directory) - ALWAYS USE BUN
 cd web && bun run dev     # Development server
 cd web && bun run build   # Build for production
 cd web && bun run lint    # Lint TypeScript/React

--- a/web/components/sections/FAQ.tsx
+++ b/web/components/sections/FAQ.tsx
@@ -18,10 +18,6 @@ const faqs = [
     answer: 'x402 is an open protocol designed for pay-per-use APIs—and it\'s ideal for AI agents. Traditional payment methods require a human to enter credit card details and manage subscriptions. With x402, your agent\'s wallet pays automatically for each scan, enabling fully autonomous operation. No human in the loop for billing. Top up via the dashboard (Stripe, Coinbase Pay) or direct deposit. The crypto layer is completely abstracted: no seed phrases, no gas fees, no complexity.',
   },
   {
-    question: 'Can I self-host Stronghold?',
-    answer: 'Yes! Stronghold is fully open source under the MIT license. You can run your own instance on your infrastructure, use your own API keys, and have complete control over your data. The self-hosted version supports manual x402 payments.',
-  },
-  {
     question: 'What threats does Stronghold detect?',
     answer: 'Stronghold uses a 4-layer scanning architecture: (1) Heuristic pattern matching for known attack signatures, (2) ML classification for prompt injection detection, (3) Semantic similarity analysis for context-aware threats, and (4) LLM classification for sophisticated attacks.',
   },

--- a/web/components/sections/Features.tsx
+++ b/web/components/sections/Features.tsx
@@ -42,7 +42,45 @@ const features = [
   },
 ]
 
+function FeatureCard({ feature, index }: { feature: typeof features[number]; index: number }) {
+  return (
+    <motion.div
+      key={feature.title}
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5, delay: index * 0.1 }}
+      whileHover={{ y: -4 }}
+      className="fortress-card rounded-xl p-8 group cursor-pointer"
+    >
+      {/* Highlight badge */}
+      <span className="inline-block px-2 py-1 rounded text-xs font-mono bg-stronghold-cyan/10 text-stronghold-cyan mb-4">
+        {feature.highlight}
+      </span>
+
+      {/* Icon */}
+      <div className="w-12 h-12 rounded-lg bg-stronghold-stone-light/50 flex items-center justify-center mb-4 group-hover:bg-stronghold-cyan/10 transition-colors">
+        <feature.icon
+          className="text-gray-400 group-hover:text-stronghold-cyan transition-colors"
+          size={24}
+        />
+      </div>
+
+      {/* Content */}
+      <h3 className="font-display text-xl font-semibold mb-3">
+        {feature.title}
+      </h3>
+      <p className="text-gray-400 text-sm leading-relaxed">
+        {feature.description}
+      </p>
+    </motion.div>
+  )
+}
+
 export default function Features() {
+  const topRow = features.slice(0, 3)
+  const bottomRow = features.slice(3)
+
   return (
     <section id="features" className="py-24 relative">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -67,39 +105,19 @@ export default function Features() {
           </p>
         </motion.div>
 
-        {/* Features Grid */}
+        {/* Features Grid - Top Row */}
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {features.map((feature, index) => (
-            <motion.div
-              key={feature.title}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
-              whileHover={{ y: -4 }}
-              className="fortress-card rounded-xl p-8 group cursor-pointer"
-            >
-              {/* Highlight badge */}
-              <span className="inline-block px-2 py-1 rounded text-xs font-mono bg-stronghold-cyan/10 text-stronghold-cyan mb-4">
-                {feature.highlight}
-              </span>
+          {topRow.map((feature, index) => (
+            <FeatureCard key={feature.title} feature={feature} index={index} />
+          ))}
+        </div>
 
-              {/* Icon */}
-              <div className="w-12 h-12 rounded-lg bg-stronghold-stone-light/50 flex items-center justify-center mb-4 group-hover:bg-stronghold-cyan/10 transition-colors">
-                <feature.icon
-                  className="text-gray-400 group-hover:text-stronghold-cyan transition-colors"
-                  size={24}
-                />
-              </div>
-
-              {/* Content */}
-              <h3 className="font-display text-xl font-semibold mb-3">
-                {feature.title}
-              </h3>
-              <p className="text-gray-400 text-sm leading-relaxed">
-                {feature.description}
-              </p>
-            </motion.div>
+        {/* Features Grid - Bottom Row (centered) */}
+        <div className="flex flex-col md:flex-row justify-center gap-6 mt-6">
+          {bottomRow.map((feature, index) => (
+            <div key={feature.title} className="w-full md:max-w-[calc((100%-1.5rem)/2)] lg:max-w-[calc((100%-3rem)/3)]">
+              <FeatureCard feature={feature} index={index + 3} />
+            </div>
           ))}
         </div>
       </div>

--- a/web/components/sections/Problem.tsx
+++ b/web/components/sections/Problem.tsx
@@ -1,28 +1,32 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { AlertTriangle, Lock, EyeOff, ShieldAlert } from 'lucide-react'
+import { Shield, Lock, Plug, Wallet } from 'lucide-react'
 
-const threats = [
+const cards = [
   {
-    icon: AlertTriangle,
-    title: 'Prompt Injection',
-    description: 'Attackers embed malicious instructions that override your system prompts.',
-  },
-  {
-    icon: EyeOff,
-    title: 'Credential Leaks',
-    description: 'AI models accidentally expose API keys, passwords, or sensitive data.',
-  },
-  {
-    icon: ShieldAlert,
-    title: 'Jailbreak Attacks',
-    description: 'Sophisticated techniques bypass safety guardrails entirely.',
+    icon: Shield,
+    title: 'Prompt Injection Defense',
+    highlight: 'Stronghold Protects',
+    description: 'Malicious instructions embedded in user inputs get caught by 4-layer scanning before they can hijack your agent\u2019s behavior.',
   },
   {
     icon: Lock,
-    title: 'Data Exfiltration',
-    description: 'Malicious prompts trick AI into sending private data to attackers.',
+    title: 'Credential Leak Prevention',
+    highlight: 'Stronghold Protects',
+    description: 'API keys, passwords, and secrets in LLM outputs are detected and blocked before they ever leave your system.',
+  },
+  {
+    icon: Plug,
+    title: 'Plug & Play for Any Agent',
+    highlight: 'Easy Integration',
+    description: 'Drop Stronghold into your existing agent setup with zero code changes. Network-level interception works with any framework or model provider.',
+  },
+  {
+    icon: Wallet,
+    title: 'Autonomous Agent Payments',
+    highlight: 'Powered by x402',
+    description: 'Your agent pays per scan automatically via its local wallet. No subscriptions, no API keys to manage, no human in the loop for billing.',
   },
 ]
 
@@ -62,7 +66,7 @@ export default function Problem() {
           >
             <div className="flex items-center gap-3 mb-6">
               <div className="w-10 h-10 rounded-lg bg-red-500/10 flex items-center justify-center">
-                <AlertTriangle className="text-red-500" size={20} />
+                <Shield className="text-red-500" size={20} />
               </div>
               <h3 className="font-display text-xl font-semibold text-red-400">
                 Without Stronghold
@@ -71,14 +75,13 @@ export default function Problem() {
 
             <ul className="space-y-4">
               {[
-                'Direct access to AI models',
-                'No input validation',
-                'Sensitive data exposed in outputs',
-                'No audit trail of requests',
-                'Attacks go undetected',
+                'Prompts hijacked by injection attacks',
+                'API keys and secrets leak through model outputs',
+                'No visibility into agent network traffic',
+                'Threats bypass your application layer undetected',
               ].map((item, i) => (
                 <li key={i} className="flex items-start gap-3 text-gray-400">
-                  <span className="text-red-500 mt-1">×</span>
+                  <span className="text-red-500 mt-1">&times;</span>
                   {item}
                 </li>
               ))}
@@ -104,14 +107,13 @@ export default function Problem() {
 
             <ul className="space-y-4">
               {[
-                'Transparent proxy intercepts all traffic',
-                '4-layer scanning detects attacks',
-                'Credential leaks blocked automatically',
-                'Complete audit trail via headers',
-                'Real-time threat detection',
+                'Every request scanned before reaching your models',
+                '4-layer defense blocks injection attacks',
+                'Credentials and secrets caught in real time',
+                'Full visibility into all agent traffic',
               ].map((item, i) => (
                 <li key={i} className="flex items-start gap-3 text-gray-300">
-                  <span className="text-stronghold-cyan mt-1">✓</span>
+                  <span className="text-stronghold-cyan mt-1">&#10003;</span>
                   {item}
                 </li>
               ))}
@@ -119,23 +121,26 @@ export default function Problem() {
           </motion.div>
         </div>
 
-        {/* Threat Grid */}
+        {/* Value Cards */}
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          {threats.map((threat, index) => (
+          {cards.map((card, index) => (
             <motion.div
-              key={threat.title}
+              key={card.title}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
-              className="fortress-card rounded-xl p-6 group hover:border-red-500/30 transition-colors"
+              className="fortress-card rounded-xl p-6 group hover:border-stronghold-cyan/30 transition-colors"
             >
-              <threat.icon
-                className="text-red-500 mb-4 group-hover:scale-110 transition-transform"
+              <card.icon
+                className="text-stronghold-cyan mb-4 group-hover:scale-110 transition-transform"
                 size={28}
               />
-              <h4 className="font-display font-semibold text-lg mb-2">{threat.title}</h4>
-              <p className="text-sm text-gray-400">{threat.description}</p>
+              <span className="inline-block px-2 py-1 rounded text-xs font-mono bg-stronghold-cyan/10 text-stronghold-cyan mb-3">
+                {card.highlight}
+              </span>
+              <h4 className="font-display font-semibold text-lg mb-2">{card.title}</h4>
+              <p className="text-sm text-gray-400">{card.description}</p>
             </motion.div>
           ))}
         </div>

--- a/web/components/sections/Solution.tsx
+++ b/web/components/sections/Solution.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Download, Power, Scan, ArrowRight } from 'lucide-react'
+import { Download, Power, CheckCircle, ArrowRight } from 'lucide-react'
 
 const steps = [
   {
@@ -20,9 +20,9 @@ const steps = [
   },
   {
     number: '03',
-    icon: Scan,
-    title: 'Scan',
-    description: 'Every request is analyzed for prompt injection, credential leaks, and jailbreak attempts. Threats blocked in under 50ms.',
+    icon: CheckCircle,
+    title: 'Verify',
+    description: 'Confirm your setup is running properly. Once enabled, Stronghold automatically scans every request and response\u2014you\u2019re protected.',
     command: 'stronghold status',
   },
 ]


### PR DESCRIPTION
## Summary
- **Problem section**: Rewrote comparison bullets to highlight specific AI agent risks (prompt injection, credential leaks, traffic visibility). Replaced generic threat cards with value-oriented cards covering defense, leak prevention, plug-and-play integration, and x402 payments. Card hover color changed from red to cyan.
- **Solution section**: Renamed step 3 from "Scan" to "Verify" with accurate description of what `stronghold status` does.
- **Features section**: Centered the last 2 feature cards on the bottom row instead of left-aligning them.
- **FAQ section**: Removed the "Can I self-host Stronghold?" question.
- **CLAUDE.md**: Added explicit bun-only package manager policy.

## Test plan
- [ ] Run `cd web && bun run dev` and visually inspect all sections
- [ ] Verify Problem section has 4 bullets per side, no "Direct access" or "Jailbreak" items
- [ ] Verify Solution step 3 says "Verify" with CheckCircle icon
- [ ] Verify Features last 2 cards are horizontally centered
- [ ] Verify FAQ has no self-hosting question
- [ ] Run `cd web && bun run lint` — passes clean